### PR TITLE
Fix README frontend path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Structure
 - /contracts — Smart contracts (Anchor / Solana)
 - /backend — Backend API server (Node.js / Express)
-- /frontend — (Future) Frontend app (Next.js / Tailwind)
+- /frontend_comparison/frontend_minimal — Sample frontend app (Next.js / Tailwind)
 - /old_versions — All early contract versions (backup)
 
 ## Description


### PR DESCRIPTION
## Summary
- document correct path to the example frontend

## Testing
- `npm test --prefix backend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6843382dbb30832786bba0a23c7afed2